### PR TITLE
Support for REU as source

### DIFF
--- a/src-c64/Makefile
+++ b/src-c64/Makefile
@@ -35,6 +35,8 @@ CFLAGS  := -Oi -DVERSION=\"$(VERSION)\"
 ASFLAGS :=
 SYSTEM  := c64
 
+LIBPATH :=
+
 # Enable verbose compilation with "make V=1"
 ifdef V
  Q :=
@@ -44,7 +46,7 @@ else
  E := @echo
 endif
 
-FLASHTOOL_CSRC := flashtool.c tapecartif.c conutil.c debugmenu.c advancedmenu.c tcrt.c
+FLASHTOOL_CSRC := flashtool.c tapecartif.c conutil.c debugmenu.c advancedmenu.c tcrt.c io.c
 FLASHTOOL_ASRC := minidelay.s getbyte_fast.s
 
 # calculate object file names
@@ -55,7 +57,7 @@ all: loader.bin flashtool.prg
 
 flashtool.prg: $(FLASHTOOL_OBJ)
 	$(E) "  LINK   $@"
-	$(Q)ld65 -o $@ -t $(SYSTEM) $^ $(SYSTEM).lib
+	$(Q)ld65 -o $@ -t $(SYSTEM) $^ $(LIBPATH)/$(SYSTEM).lib
 
 %.s: %.c
 	$(E) "  CC     $<"

--- a/src-c64/advancedmenu.c
+++ b/src-c64/advancedmenu.c
@@ -188,7 +188,7 @@ static void write_custom_loader(void) {
   cputsxy(2, STATUS_START - 2, "Loader updated");
 
  fail:
-  cbm_close(CBM_LFN);
+  tc_cbm_close(CBM_LFN);
 }
 
 

--- a/src-c64/advancedmenu.c
+++ b/src-c64/advancedmenu.c
@@ -39,6 +39,7 @@
 #include "globals.h"
 #include "tapecartif.h"
 #include "advancedmenu.h"
+#include "io.h"
 
 int  byteswritten;
 long bytesread;
@@ -63,7 +64,7 @@ static void write_datafile(void) {
   if (!read_string(fname, FILENAME_LENGTH, 15, 5))
     return;
 
-  res = cbm_open(CBM_LFN, current_device, 3, fname);
+  res = tc_cbm_open(CBM_LFN, current_device, 3, fname);
   if (res != 0) {
     cputsxy(2, STATUS_START - 2, "Failed to open data file");
     return;
@@ -76,7 +77,7 @@ static void write_datafile(void) {
   cputsxy(2, STATUS_START - 2, "Write successful");
   cputsxy(2, STATUS_START - 1, "Remember to set data start+length!");
 
-  cbm_close(CBM_LFN);
+  tc_cbm_close(CBM_LFN);
 }
 
 
@@ -110,7 +111,7 @@ void dump_flash_to_file(void) {
     tapecart_read_flash_fast(flash_offset, bytesread, databuffer);
     bordercolor(++i);
 
-    byteswritten = cbm_write(CBM_LFN, databuffer, bytesread);
+    byteswritten = tc_cbm_write(CBM_LFN, databuffer, bytesread);
     if (byteswritten != bytesread) {
       cputsxy(2, STATUS_START - 2, "Failed to write to file");
       goto fail;
@@ -124,7 +125,7 @@ void dump_flash_to_file(void) {
  fail:
   VIC.ctrl1 |= (1 << 4); // un-blank screen
   bordercolor(COLOR_GRAY1);
-  cbm_close(CBM_LFN);
+  tc_cbm_close(CBM_LFN);
 }
 
 
@@ -139,7 +140,7 @@ static void dump_flash(void) {
   if (!read_string(fname, FILENAME_LENGTH, 16, 5))
     return;
 
-  res = cbm_open(CBM_LFN, current_device, 1, fname);
+  res = tc_cbm_open(CBM_LFN, current_device, 1, fname);
   if (res != 0) {
     cputsxy(2, STATUS_START - 2, "Failed to open file");
     return;
@@ -167,7 +168,7 @@ static void write_custom_loader(void) {
   if (!read_string(fname, FILENAME_LENGTH, 12, 4))
     return;
 
-  res = cbm_open(CBM_LFN, current_device, 4, fname);
+  res = tc_cbm_open(CBM_LFN, current_device, 4, fname);
   if (res != 0) {
     cputsxy(2, STATUS_START - 2, "Failed to open loader file");
     return;
@@ -175,7 +176,7 @@ static void write_custom_loader(void) {
 
   cputsxy(2, 6, "Writing...");
 
-  len = cbm_read(CBM_LFN, databuffer, LOADER_LENGTH + 2);
+  len = tc_cbm_read(CBM_LFN, databuffer, LOADER_LENGTH + 2);
   if (len != LOADER_LENGTH + 2) {
     gotoxy(2, STATUS_START - 2);
     cprintf("Error: Read only %d byte from the file", len);
@@ -199,7 +200,7 @@ static void dump_loader(void) {
   if (!read_string(fname, FILENAME_LENGTH, 16, 5))
     return;
 
-  res = cbm_open(CBM_LFN, current_device, 1, fname);
+  res = tc_cbm_open(CBM_LFN, current_device, 1, fname);
   if (res != 0) {
     cputsxy(2, STATUS_START - 2, "Failed to open file");
     return;
@@ -209,13 +210,13 @@ static void dump_loader(void) {
   databuffer[0] = 0x51;
   databuffer[1] = 0x03;
 
-  byteswritten = cbm_write(CBM_LFN, databuffer, LOADER_LENGTH + 2);
+  byteswritten = tc_cbm_write(CBM_LFN, databuffer, LOADER_LENGTH + 2);
   if (byteswritten != LOADER_LENGTH + 2) {
     cputsxy(2, STATUS_START - 2, "Failed to write file");
   } else {
     cputsxy(2, STATUS_START - 2, "Dump successful");
   }
-  cbm_close(CBM_LFN);
+  tc_cbm_close(CBM_LFN);
 }
 
 

--- a/src-c64/flashtool.c
+++ b/src-c64/flashtool.c
@@ -349,11 +349,7 @@ int main(void) {
 
   display_devicenum();
 
-  if (!tapecart_cmdmode()) {
-    gotoxy(0, 3);
-    cprintf("Error: Tapecart not detected.\n");
-    return 0;
-  }
+  tapecart_cmdmode();
 
   while (1) {
     display_status();

--- a/src-c64/flashtool.c
+++ b/src-c64/flashtool.c
@@ -44,6 +44,7 @@
 #include "globals.h"
 #include "tapecartif.h"
 #include "tcrt.h"
+#include "io.h"
 
 const uint8_t default_loader[LOADER_LENGTH] = {
   #include "loader.h"
@@ -155,7 +156,7 @@ bool write_file(long limit) {
     if (limit >= 0 && to_read > limit)
       to_read = limit;
 
-    len = cbm_read(CBM_LFN, databuffer, to_read);
+    len = tc_cbm_read(CBM_LFN, databuffer, to_read);
 
     if (len > 0) {
       if (erase_pages && pages_erased == 0) {
@@ -197,13 +198,13 @@ static void write_onefiler(void) {
   if (!read_string(fname, FILENAME_LENGTH, 16, 4))
     return;
 
-  res = cbm_open(CBM_LFN, current_device, 0, fname);
+  res = tc_cbm_open(CBM_LFN, current_device, 0, fname);
   if (res != 0) {
     cputsxy(2, STATUS_START - 2, "Failed to open data file");
     return;
   }
 
-  len = cbm_read(CBM_LFN, &loadaddr, 2);
+  len = tc_cbm_read(CBM_LFN, &loadaddr, 2);
   if (len != 2) {
     cputsxy(2, STATUS_START - 2, "Failed to read load address");
     goto fail;
@@ -255,7 +256,7 @@ static void write_onefiler(void) {
   }
 
   /* read remainder of first block into buffer */
-  len = cbm_read(CBM_LFN, databuffer + flash_offset, page_size - flash_offset);
+  len = tc_cbm_read(CBM_LFN, databuffer + flash_offset, page_size - flash_offset);
 
   /* write it */
   gotoxy(0, 9);
@@ -278,7 +279,7 @@ static void write_onefiler(void) {
   cputsxy(2, STATUS_START - 2, "Write successful");
 
  fail:
-  cbm_close(CBM_LFN);
+  tc_cbm_close(CBM_LFN);
 }
 
 

--- a/src-c64/io.c
+++ b/src-c64/io.c
@@ -1,0 +1,133 @@
+/* tapecart - a tape port storage pod for the C64
+   All rights reserved.
+
+   This file is copyrighted by markusC64
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+   DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+   OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+   OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+   SUCH DAMAGE.
+
+
+   io.c: wrappr code for cbm_* functions for accesing reu and normal cbm devices
+         treating the reu content as single file where the 1st four bytes containing
+	 the file size
+*/
+
+
+
+#include "io.h"
+#include <conio.h>
+#include <stdio.h>
+#include <string.h>
+
+signed char       reuLfn = -1;
+unsigned long int reuSize;
+unsigned long int reufilepos;
+
+
+/* Copy 'size' bytes from REU memory starting at page 'page' offset 'offset' to 'dst' */
+void transferFromReu(short int page, char offset, unsigned short int size, void * dst)
+{
+   *(unsigned short *) (0xdf02) = (unsigned short) dst;
+   *(unsigned char *) (0xdf04)  = offset;
+   *(unsigned short *) (0xdf05) = page;
+   *(unsigned short *) (0xdf07) = size;
+   *(unsigned char *) (0xdf09)  = 0;
+   *(unsigned char *) (0xdf0a)  = 0;
+   *(unsigned char *) (0xdf01)  = 253;
+}
+
+/* cbm_open wrapper with reu support, use "r:" as filename to access reu */
+unsigned char __fastcall__ tc_cbm_open(unsigned char lfn, unsigned char device, unsigned char sec_addr, const char * name)
+{
+   if ( !strcmp(name, "r:"))
+   {
+      if (reuLfn != -1)
+      {
+         return 1;
+      }
+
+      reuLfn     = lfn;
+      reufilepos = 0;
+
+      transferFromReu(0, 0, 4, &reuSize);
+
+      return 0;
+   }
+   else
+   {
+      return cbm_open(lfn, device, sec_addr, name);
+   }
+}
+
+/* cbm_close wrapper with reu support */
+void __fastcall__ tc_cbm_close(unsigned char lfn)
+{
+   if (lfn == reuLfn)
+   {
+      reuLfn = -1;
+   }
+   else
+   {
+      cbm_close(lfn);
+   }
+}
+
+/* cbm_read wrapper with reu support */
+int __fastcall__ tc_cbm_read(unsigned char lfn, void * buffer, unsigned int size)
+{
+   unsigned long int page;
+   unsigned short    idx;
+
+   if (lfn != reuLfn)
+   {
+      return cbm_read(lfn, buffer, size);
+   }
+
+   page = (reufilepos + 4) >> 8;
+   idx  = (reufilepos + 4) & 0xff;
+
+   if (size > reuSize - reufilepos)
+   {
+      size = reuSize - reufilepos;
+   }
+
+   if ( !size)
+   {
+      return 0;
+   }
+
+   transferFromReu(page, idx, size, buffer);
+
+   reufilepos += size;
+
+   return size;
+}
+
+/* cbm_write with reu support - without reu write support */
+int __fastcall__ tc_cbm_write(unsigned char lfn, const void * buffer, unsigned int size)
+{
+   if (lfn != reuLfn)
+   {
+      return cbm_write(lfn, buffer, size);
+   }
+
+   return 0;
+}

--- a/src-c64/io.h
+++ b/src-c64/io.h
@@ -1,0 +1,43 @@
+/* tapecart - a tape port storage pod for the C64
+   All rights reserved.
+
+   This file is copyrighted by markusC64
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+   DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+   OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+   OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+   SUCH DAMAGE.
+
+   io.c: wrappr code for cbm_* functions for accesing reu and normal cbm devices
+         treating the reu content as single file where the 1st four bytes containing
+	 the file size
+*/
+
+/* cbm_open wrapper with reu support, use "r:" as filename to access reu */
+
+unsigned char __fastcall__ tc_cbm_open(unsigned char lfn, unsigned char device, unsigned char sec_addr, const char * name);
+
+/* cbm_close wrapper with reu support */
+void __fastcall__ tc_cbm_close(unsigned char lfn);
+
+/* cbm_read wrapper with reu support */
+int __fastcall__ tc_cbm_read(unsigned char lfn, void * buffer, unsigned int size);
+
+/* cbm_write with reu support - without reu write support */
+int __fastcall__ tc_cbm_write(unsigned char lfn, const void * buffer, unsigned int size);

--- a/src-c64/tapecartif.h
+++ b/src-c64/tapecartif.h
@@ -40,7 +40,7 @@
 #define FILENAME_LENGTH 16
 #define LOADER_LENGTH   171
 
-bool     tapecart_cmdmode(void);
+void     tapecart_cmdmode(void);
 void     tapecart_streammode(void);
 void     tapecart_sendbyte(uint8_t byte);
 uint8_t  tapecart_getbyte(void);

--- a/src-c64/tcrt.c
+++ b/src-c64/tcrt.c
@@ -37,6 +37,7 @@
 #include "globals.h"
 #include "tapecartif.h"
 #include "tcrt.h"
+#include "io.h"
 
 const uint8_t tcrt_header[] = {
   0x74, 0x61, 0x70, 0x65,
@@ -63,13 +64,13 @@ void write_tcrt(void) {
   if (!read_string(fname, FILENAME_LENGTH, 16, 4))
     return;
 
-  res = cbm_open(CBM_LFN, current_device, 0, fname);
+  res = tc_cbm_open(CBM_LFN, current_device, 0, fname);
   if (res != 0) {
     cputsxy(2, STATUS_START - 2, "Failed to open file");
     return;
   }
 
-  bytesread = cbm_read(CBM_LFN, databuffer, TCRT_OFFSET_FLASHDATA);
+  bytesread = tc_cbm_read(CBM_LFN, databuffer, TCRT_OFFSET_FLASHDATA);
   if (bytesread != TCRT_OFFSET_FLASHDATA) {
     gotoxy(2, STATUS_START - 2);
     cprintf("Error: Read only %d byte from the file", len);
@@ -156,7 +157,7 @@ void write_tcrt(void) {
   cputsxy(2, STATUS_START - 2, "Write successful");
 
  fail:
-  cbm_close(CBM_LFN);
+  tc_cbm_close(CBM_LFN);
 }
 
 
@@ -172,7 +173,7 @@ void dump_tcrt(void) {
   if (!read_string(fname, FILENAME_LENGTH, 16, 4))
     return;
 
-  res = cbm_open(CBM_LFN, current_device, 1, fname);
+  res = tc_cbm_open(CBM_LFN, current_device, 1, fname);
   if (res != 0) {
     cputsxy(2, STATUS_START - 2, "Failed to open file");
     return;
@@ -194,10 +195,10 @@ void dump_tcrt(void) {
 
   memcpy(databuffer + TCRT_OFFSET_FLASHLENGTH, &total_size, sizeof(total_size));
 
-  byteswritten = cbm_write(CBM_LFN, databuffer, TCRT_OFFSET_FLASHDATA);
+  byteswritten = tc_cbm_write(CBM_LFN, databuffer, TCRT_OFFSET_FLASHDATA);
   if (byteswritten != TCRT_OFFSET_FLASHDATA) {
     cputsxy(2, STATUS_START - 2, "Failed to write to file");
-    cbm_close(CBM_LFN);
+    tc_cbm_close(CBM_LFN);
     return;
   }
 


### PR DESCRIPTION
Using "r:" as filename will use the reu as source for all situations where a file is read.

To be used with 141 Ultimate II(+) Firmware 3.1a_500+_v3 (to be released soon).